### PR TITLE
[Minor] [Cosmetic] Modify English display text

### DIFF
--- a/Mods/NoManualDelivery/translations/nomanualdelivery_template.pot
+++ b/Mods/NoManualDelivery/translations/nomanualdelivery_template.pot
@@ -5,7 +5,7 @@ msgstr ""
 
 #. NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.NAME
 msgctxt "NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.NAME"
-msgid "Duplicants can always picking up Food and Medicine."
+msgid "Duplicants can always pick up Food and Medicine."
 msgstr ""
 
 #. NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.TOOLTIP

--- a/Mods/NoManualDelivery/translations/ru.po
+++ b/Mods/NoManualDelivery/translations/ru.po
@@ -5,7 +5,7 @@ msgstr ""
 
 #. NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.NAME
 msgctxt "NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.NAME"
-msgid "Duplicants can always picking up Food and Medicine."
+msgid "Duplicants can always pick up Food and Medicine."
 msgstr "Дупликанты всегда могут брать еду и лекарства."
 
 #. NoManualDelivery.STRINGS.OPTIONS.ALLOWALWAYSPICKUPEDIBLE.TOOLTIP

--- a/src/NoManualDelivery/STRINGS.cs
+++ b/src/NoManualDelivery/STRINGS.cs
@@ -13,7 +13,7 @@ namespace NoManualDelivery
         {
             public class ALLOWALWAYSPICKUPEDIBLE
             {
-                public static LocString NAME = "Duplicants can always picking up Food and Medicine.";
+                public static LocString NAME = "Duplicants can always pick up Food and Medicine.";
                 public static LocString TOOLTIP = string.Concat(new string[]
                 {
                     "Duplicants will ignore the ",


### PR DESCRIPTION
# Issue

The first checkbox should say "can always pick up"
![image](https://user-images.githubusercontent.com/10776890/178533488-ecf21979-7b49-4313-aa31-80df4e300cf3.png)

# Fix

Replace the strings in code

# Concerns

1. There are [other hits](https://github.com/SanchozzDeponianin/ONIMods/search?q=%22can+always+picking%22) in the [archived_versions/vanilla_legacy](https://github.com/SanchozzDeponianin/ONIMods/tree/17c4310de4daf37374238a48009fa2daf6539742/Mods/NoManualDelivery/archived_versions/vanilla_legacy) folder which I did not touch. _Rationale: 'archive' may intend to be archived and read-only._
2. If I understand correctly, the display text is being taken from a `key` (msgid), and [for English](https://github.com/SanchozzDeponianin/ONIMods/blob/b7f3bad924e4418f6cea2af818dfa0023c755370/Mods/NoManualDelivery/translations/nomanualdelivery_template.pot) the `""` means "just use the msgid". If this msgid is persisted to any other files, or the mod delivered in multiple parts, changing a key would be dangerous. _Alternative: modify `msgstr` on line 9 of nomanualdelivery_template.pot instead of `msgid` in multiple files._

# Testing

Did not test, I'm not familiar with ONI modding. If you do not wish to take it without me testing let me know!