### PR TITLE
Include customName in smelter steel recipe initialization

### DIFF
--- a/src/Smelter/SmelterConfig.cs
+++ b/src/Smelter/SmelterConfig.cs
@@ -262,6 +262,7 @@ namespace Smelter
                     {
                         time = recipe.time * fabricationTimeMultiplier,
                         description = recipe.description,
+                        customName = recipe.customName, //if the steel recipe is from a mod and uses a custom name, this is required, otherwise the SearchUtil.CacheTechs crashes due to an empty name
                         nameDisplay = recipe.nameDisplay,
                         fabricators = new List<Tag> { TagManager.Create(ID) }
                     };


### PR DESCRIPTION
if the metal refinery has a custom steel recipe that uses nameDisplay.Custom, the game will crash on load due to SearchUtil.CacheTechs not handling an empty recipe name properly.

including the name fixes that.