### PR TITLE
Add merged large fridge from Ronivan's Legacy

### DIFF
--- a/src/NoManualDelivery/Patches.cs
+++ b/src/NoManualDelivery/Patches.cs
@@ -84,8 +84,9 @@ namespace NoManualDelivery
             // Aquatic Farm https://steamcommunity.com/sharedfiles/filedetails/?id=1910961538
             "AquaticFarm",
             // Advanced Refrigeration https://steamcommunity.com/sharedfiles/filedetails/?id=2021324045
+            // Ronivan's Legacy https://steamcommunity.com/sharedfiles/filedetails/?id=3557584850
             "SimpleFridge", "FridgeRed", "FridgeYellow", "FridgeBlue", "FridgeAdvanced",
-            "FridgePod", "SpaceBox", "HightechSmallFridge", "HightechBigFridge",
+            "FridgePod", "SpaceBox", "HightechSmallFridge", "HightechBigFridge", "AIO_FridgeLarge"
             // Storage Pod  https://steamcommunity.com/sharedfiles/filedetails/?id=1873476551
             "StoragePodConfig",
             // Big Storage  https://steamcommunity.com/sharedfiles/filedetails/?id=1913589787


### PR DESCRIPTION
Ronivan's Legacy merges the 4 buildings

"FridgeAdvanced", "FridgeBlue", "FridgeRed", "FridgeYellow" 

into a single building with skins (klei "blueprints"). 
The id of that building is "AIO_FridgeLarge", which is added to the list in this PR.

I have left those listed to not remove the feature from the old mod